### PR TITLE
ADBDEV-8360: Automate Madlib tests with Github Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,89 @@
+name: MADlib
+
+on:
+  push:
+    branches: [ madlib2-master ]
+  pull_request:
+    branches: [ madlib2-master ]
+
+# Concurrency control to cancel previous runs on new push to same PR/branch
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true  # Automatically cancel any previous runs for the same group
+
+jobs:
+  job:
+    name: ${{ matrix.name }} ${{ matrix.version }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Greengage
+            version: 6
+            image: ghcr.io/greengagedb/greengage/ggdb6_ubuntu:latest
+            madlib_port: greenplum
+            user: gpadmin
+            setup_working_directory: /home/gpadmin
+            test_working_directory: /home/gpadmin
+            log: /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/*/*/pg_log
+          - name: Greengage
+            version: 7
+            image: ghcr.io/greengagedb/greengage/ggdb7_ubuntu:latest
+            madlib_port: greenplum
+            user: gpadmin
+            setup_working_directory: /home/gpadmin
+            test_working_directory: /home/gpadmin
+            log: /home/gpadmin/gpdb_src/gpAux/gpdemo/datadirs/*/*/log
+          - name: PostgreSQL
+            version: 15
+            image: ubuntu:22.04
+            madlib_port: postgres
+            user: postgres
+            setup_working_directory: /home
+            test_working_directory: /var/lib/postgresql
+            log: /var/lib/postgresql/data/log
+    container:
+      image: ${{ matrix.image }}
+      options:
+        --sysctl "kernel.sem=500 1024000 200 4096"
+    env:
+      HOME: ${{ matrix.test_working_directory }}
+      MADLIB_PORT: ${{ matrix.madlib_port }}
+      USER: ${{ matrix.user }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Install
+        run: "$GITHUB_WORKSPACE/ci/install.bash"
+        working-directory: ${{ matrix.setup_working_directory }}
+
+      - name: Create
+        run: su -p ${{ matrix.user }} "$GITHUB_WORKSPACE/ci/create.bash"
+        working-directory: ${{ matrix.test_working_directory }}
+
+      - name: Install-check
+        if: ${{ !cancelled() }}
+        run: su -p ${{ matrix.user }} "$GITHUB_WORKSPACE/ci/test.bash" install-check
+        working-directory: ${{ matrix.test_working_directory }}
+
+      - name: Dev-check
+        if: ${{ !cancelled() }}
+        run: su -p ${{ matrix.user }} "$GITHUB_WORKSPACE/ci/test.bash" dev-check
+        working-directory: ${{ matrix.test_working_directory }}
+
+      - name: Unit-test
+        if: ${{ !cancelled() }}
+        run: su -p ${{ matrix.user }} "$GITHUB_WORKSPACE/ci/test.bash" unit-test
+        working-directory: ${{ matrix.test_working_directory }}
+
+      - name: Artifact
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.madlib_port }}_${{ matrix.version }}
+          path: |
+            /tmp/madlib.*
+            ${{ matrix.log }}

--- a/ci/README.md
+++ b/ci/README.md
@@ -1,0 +1,34 @@
+## How to run tests
+
+Greengage 6:
+```bash
+docker container rm madlib -f
+docker run --detach --entrypoint tail --env MADLIB_PORT=greenplum --name madlib --sysctl "kernel.sem=500 1024000 200 4096" --volume .:/home/gpadmin/madlib ghcr.io/greengagedb/greengage/ggdb6_ubuntu:latest -f /dev/null
+docker exec madlib madlib/ci/install.bash
+docker exec madlib su -p gpadmin madlib/ci/create.bash
+docker exec madlib su -p gpadmin madlib/ci/test.bash install-check
+docker exec madlib su -p gpadmin madlib/ci/test.bash dev-check
+docker exec madlib su -p gpadmin madlib/ci/test.bash unit-test
+```
+
+Greengage 7:
+```bash
+docker container rm madlib -f
+docker run --detach --entrypoint tail --env MADLIB_PORT=greenplum --name madlib --sysctl "kernel.sem=500 1024000 200 4096" --volume .:/home/gpadmin/madlib ghcr.io/greengagedb/greengage/ggdb7_ubuntu:latest -f /dev/null
+docker exec madlib madlib/ci/install.bash
+docker exec madlib su -p gpadmin madlib/ci/create.bash
+docker exec madlib su -p gpadmin madlib/ci/test.bash install-check
+docker exec madlib su -p gpadmin madlib/ci/test.bash dev-check
+docker exec madlib su -p gpadmin madlib/ci/test.bash unit-test
+```
+
+PostgreSQL 15
+```bash
+docker container rm madlib -f
+docker run --detach --entrypoint tail --env MADLIB_PORT=postgres --name madlib --sysctl "kernel.sem=500 1024000 200 4096" --volume .:/home/madlib --workdir /home ubuntu:22.04 -f /dev/null
+docker exec madlib madlib/ci/install.bash
+docker exec madlib su -p postgres madlib/ci/create.bash
+docker exec madlib su -p postgres madlib/ci/test.bash install-check
+docker exec madlib su -p postgres madlib/ci/test.bash dev-check
+docker exec madlib su -p postgres madlib/ci/test.bash unit-test
+```

--- a/ci/create.bash
+++ b/ci/create.bash
@@ -1,0 +1,26 @@
+#!/bin/bash -l
+
+set -exo pipefail
+
+case "$MADLIB_PORT" in
+    greenplum)
+        source /usr/local/greengage-db-devel/greengage_path.sh
+        source gpdb_src/gpAux/gpdemo/gpdemo-env.sh
+    ;;
+    postgres)
+        export LD_LIBRARY_PATH=/usr/local/lib
+        export PGDATA=/var/lib/postgresql/data
+        initdb --auth=trust --data-checksums --encoding=UTF8
+        echo "logging_collector = 'on'" >>/var/lib/postgresql/data/postgresql.auto.conf
+        pg_ctl -w start
+    ;;
+esac
+
+createdb madlib
+
+psql -ad madlib <<EOF
+create extension if not exists plpython3u;
+create schema if not exists madlib;
+create extension if not exists madlib schema madlib;
+select madlib.version();
+EOF

--- a/ci/create.bash
+++ b/ci/create.bash
@@ -5,6 +5,9 @@ set -exo pipefail
 case "$MADLIB_PORT" in
     greenplum)
         source /usr/local/greengage-db-devel/greengage_path.sh
+        pushd gpdb_src/gpAux/gpdemo
+        make create-demo-cluster WITH_MIRRORS=true
+        popd
         source gpdb_src/gpAux/gpdemo/gpdemo-env.sh
     ;;
     postgres)

--- a/ci/install.bash
+++ b/ci/install.bash
@@ -1,0 +1,112 @@
+#!/bin/bash -l
+
+set -exo pipefail
+
+case "$MADLIB_PORT" in
+    postgres)
+        export DEBIAN_FRONTEND=noninteractive
+        groupadd --system --gid 999 postgres
+        useradd --system --uid 999 --home /var/lib/postgresql --shell /bin/bash --gid postgres postgres
+        install -d -m 0755 -o postgres -g postgres /var/lib/postgresql
+        install -d -m 0700 -o postgres -g postgres /var/lib/postgresql/data
+        apt-get update
+        apt-get install -y \
+            bison \
+            clang \
+            cmake \
+            curl \
+            flex \
+            g++ \
+            gcc \
+            git-core \
+            libbz2-dev \
+            libgss-dev \
+            libkrb5-dev \
+            libldap-common \
+            libldap-dev \
+            liblz4-dev \
+            libpam-dev \
+            libperl-dev \
+            libreadline-dev \
+            libssl-dev \
+            libxml2-dev \
+            libxslt-dev \
+            libyaml-dev \
+            libzstd-dev \
+            llvm \
+            locales \
+            pkg-config \
+            python3-dev \
+            python3-pip \
+            uuid-dev \
+            zlib1g-dev
+        git clone -b REL_15_STABLE https://github.com/postgres/postgres.git
+        pushd postgres
+        ./configure \
+            CFLAGS="-O3 -fargument-noalias-global -fno-omit-frame-pointer" \
+            --disable-rpath \
+            --enable-cassert \
+            --enable-debug \
+            --enable-depend \
+            --enable-integer-datetimes \
+            --enable-thread-safety \
+            --prefix=/usr/local \
+            --with-gnu-ld \
+            --with-gssapi \
+            --with-icu \
+            --with-includes=/usr/local/include \
+            --with-ldap \
+            --with-libedit-preferred \
+            --with-libraries=/usr/local/lib \
+            --with-libxml \
+            --with-libxslt \
+            --with-llvm \
+            --with-lz4 \
+            --with-openssl \
+            --with-pam \
+            --with-perl \
+            --with-pgport=5432 \
+            --with-python \
+            --with-system-tzdata=/usr/share/zoneinfo \
+            --with-uuid=e2fs \
+            --with-zstd
+        make -j"$(nproc)" -C src install
+        make -j"$(nproc)" -C contrib install
+        make -j"$(nproc)" submake-libpq submake-libpgport submake-libpgfeutils install
+        popd
+    ;;
+esac
+
+which pip3 || curl https://bootstrap.pypa.io/pip/get-pip.py | python3
+
+pip3 install --no-cache-dir \
+    dill==0.3.7 \
+    grpcio==1.57.0 \
+    hyperopt==0.2.5 \
+    mock \
+    numpy==1.25.2 \
+    pandas==2.0.3 \
+    protobuf==3.19.4 \
+    pypmml \
+    pyxb \
+    pyxb-x==1.2.6.1 \
+    pyyaml==6.0.1 \
+    scikit-learn==1.3.0 \
+    scipy==1.11.2 \
+    tensorflow==2.10 \
+    xgboost==1.7.6
+
+case "$MADLIB_PORT" in
+    greenplum)
+        source gpdb_src/concourse/scripts/common.bash
+        install_and_configure_gpdb
+        gpdb_src/concourse/scripts/setup_gpadmin_user.bash
+        make_cluster
+    ;;
+esac
+
+pushd "$(dirname "$0")/.."
+./configure
+make -j"$(nproc)" install
+make -j"$(nproc)" extension-install
+popd

--- a/ci/install.bash
+++ b/ci/install.bash
@@ -101,7 +101,6 @@ case "$MADLIB_PORT" in
         source gpdb_src/concourse/scripts/common.bash
         install_and_configure_gpdb
         gpdb_src/concourse/scripts/setup_gpadmin_user.bash
-        make_cluster
     ;;
 esac
 

--- a/ci/install.bash
+++ b/ci/install.bash
@@ -5,10 +5,6 @@ set -exo pipefail
 case "$MADLIB_PORT" in
     postgres)
         export DEBIAN_FRONTEND=noninteractive
-        groupadd --system --gid 999 postgres
-        useradd --system --uid 999 --home /var/lib/postgresql --shell /bin/bash --gid postgres postgres
-        install -d -m 0755 -o postgres -g postgres /var/lib/postgresql
-        install -d -m 0700 -o postgres -g postgres /var/lib/postgresql/data
         apt-get update
         apt-get install -y \
             bison \
@@ -101,6 +97,12 @@ case "$MADLIB_PORT" in
         source gpdb_src/concourse/scripts/common.bash
         install_and_configure_gpdb
         gpdb_src/concourse/scripts/setup_gpadmin_user.bash
+    ;;
+    postgres)
+        groupadd --system --gid 999 postgres
+        useradd --system --uid 999 --home /var/lib/postgresql --shell /bin/bash --gid postgres postgres
+        install -d -m 0755 -o postgres -g postgres /var/lib/postgresql
+        install -d -m 0700 -o postgres -g postgres /var/lib/postgresql/data
     ;;
 esac
 

--- a/ci/test.bash
+++ b/ci/test.bash
@@ -1,0 +1,17 @@
+#!/bin/bash -l
+
+set -exo pipefail
+
+case "$MADLIB_PORT" in
+    greenplum)
+        source /usr/local/greengage-db-devel/greengage_path.sh
+        source gpdb_src/gpAux/gpdemo/gpdemo-env.sh
+    ;;
+    postgres)
+        export LD_LIBRARY_PATH=/usr/local/lib
+        export PGDATA=/var/lib/postgresql/data
+    ;;
+esac
+
+export PATH="$PATH:/usr/local/madlib/bin"
+madpack -p "$MADLIB_PORT" -c /madlib "$1"

--- a/src/madpack/madpack.py
+++ b/src/madpack/madpack.py
@@ -14,6 +14,7 @@ import tempfile
 import shutil
 
 import upgrade_util as uu
+import utilities
 from utilities import _write_to_file
 from utilities import error_
 from utilities import get_dbver
@@ -1575,3 +1576,6 @@ if __name__ == "__main__":
         shutil.rmtree(tmpdir)
     else:
         print("INFO: Log files saved in " + tmpdir)
+
+    if utilities._error:
+        exit(1)

--- a/src/madpack/utilities.py
+++ b/src/madpack/utilities.py
@@ -34,6 +34,7 @@ else:
 # Import MADlib python modules
 import configyml
 
+_error = False
 # Some read-only variables
 this = os.path.basename(sys.argv[0])    # name of this script
 
@@ -51,6 +52,8 @@ def error_(src_name, msg, stop=False):
         @param msg error message
         @param stop program exit flag
     """
+    global _error
+    _error = True
     # Print to stdout
     print(("{0}: ERROR : {1}".format(src_name, msg)))
     # stack trace is not printed

--- a/src/ports/postgres/cmake/PostgreSQLUtils.cmake
+++ b/src/ports/postgres/cmake/PostgreSQLUtils.cmake
@@ -6,6 +6,10 @@ function(define_postgresql_features IN_VERSION OUT_FEATURES)
         list(APPEND ${OUT_FEATURES} __HAS_BOOL_TO_TEXT_CAST__)
     endif()
 
+    if(${IN_VERSION} VERSION_GREATER "14.0")
+        list(APPEND ${OUT_FEATURES} USE_COMPATIBLE_ARRAY)
+    endif()
+
     # Pass values to caller
     set(${OUT_FEATURES} "${${OUT_FEATURES}}" PARENT_SCOPE)
 endfunction(define_postgresql_features)


### PR DESCRIPTION
Automate MADlib tests with GitHub actions

Add:
1) exit code 1 on errors to the madpack utility

2) support for USE_COMPATIBLE_ARRAY in the CMake file, as is done in the
madpack utility

3) install.bash file for installing the madpack utility and the MADlib
extension, as well as all necessary dependencies for all tests

4) create.bash file for creating a madlib database and installing the madlib
extension into the madlib schema for all tests

5) test.bash file for running install-check, dev-check, or unit-test tests in
the madlib database

6) README.md file with a description of manually running all tests on Greengage
6 and 7, as well as on PostgreSQL 15

7) ci.yml file for automatically running all tests on GitHub on Greengage 6 and
7, as well as on PostgreSQL 15

Note:
Currently, some tests are failing; these will be fixed in the future.

Ticket: ADBDEV-8360